### PR TITLE
Save 134 bytes by removing Yoast comment

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -165,3 +165,8 @@ function susty_dequeue_dashicons() {
 		wp_deregister_style( 'dashicons' );
 	}
 }
+
+// Remove comment added by Yoast
+add_action('wp_head',function() { ob_start(function($o) {
+ return preg_replace('/^\n?<!--.*?[Y]oast.*?-->\n?$/mi','',$o);
+}); },~PHP_INT_MAX);


### PR DESCRIPTION
This removed the comment that Yoast adds to every page, thus saving 134 bytes. 

```
<!-- This site is optimized with the Yoast SEO plugin v7.8 - https://yoast.com/wordpress/plugins/seo/ -->

<!-- / Yoast SEO plugin. -->
```