### PR TITLE
Fix a11y link contrast

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -79,20 +79,6 @@ if ( ! function_exists( 'susty_setup' ) ) :
 			'flex-width'  => true,
 			'flex-height' => true,
 		) );
-
-		/**
-		 * Remove core Emoji support.
-		 * 
-		 * @link https://wordpress.stackexchange.com/a/185578
-		 */
-		remove_action( 'admin_print_styles', 'print_emoji_styles' );
-		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
-		remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
-		remove_action( 'wp_print_styles', 'print_emoji_styles' );
-		remove_filter( 'wp_mail', 'wp_staticize_emoji_for_email' );
-		remove_filter( 'the_content_feed', 'wp_staticize_emoji' );
-		remove_filter( 'comment_text_rss', 'wp_staticize_emoji' );
-		add_filter( 'emoji_svg_url', '__return_false' );
 	}
 endif;
 add_action( 'after_setup_theme', 'susty_setup' );
@@ -147,6 +133,9 @@ require get_template_directory() . '/inc/customizer.php';
 if ( defined( 'JETPACK__VERSION' ) ) {
 	require get_template_directory() . '/inc/jetpack.php';
 }
+
+remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
+remove_action( 'wp_print_styles', 'print_emoji_styles' );
 
 function susty_nav_rewrite_rule() {
 	add_rewrite_rule( 'menu', 'index.php?menu=true', 'top' );

--- a/functions.php
+++ b/functions.php
@@ -79,6 +79,20 @@ if ( ! function_exists( 'susty_setup' ) ) :
 			'flex-width'  => true,
 			'flex-height' => true,
 		) );
+
+		/**
+		 * Remove core Emoji support.
+		 * 
+		 * @link https://wordpress.stackexchange.com/a/185578
+		 */
+		remove_action( 'admin_print_styles', 'print_emoji_styles' );
+		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
+		remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
+		remove_action( 'wp_print_styles', 'print_emoji_styles' );
+		remove_filter( 'wp_mail', 'wp_staticize_emoji_for_email' );
+		remove_filter( 'the_content_feed', 'wp_staticize_emoji' );
+		remove_filter( 'comment_text_rss', 'wp_staticize_emoji' );
+		add_filter( 'emoji_svg_url', '__return_false' );
 	}
 endif;
 add_action( 'after_setup_theme', 'susty_setup' );
@@ -133,9 +147,6 @@ require get_template_directory() . '/inc/customizer.php';
 if ( defined( 'JETPACK__VERSION' ) ) {
 	require get_template_directory() . '/inc/jetpack.php';
 }
-
-remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
-remove_action( 'wp_print_styles', 'print_emoji_styles' );
 
 function susty_nav_rewrite_rule() {
 	add_rewrite_rule( 'menu', 'index.php?menu=true', 'top' );

--- a/style.css
+++ b/style.css
@@ -911,11 +911,11 @@ article > header > h1, article > header > h2 {
 }
 
 .entry-meta {
-	color: rgb(179, 179, 179);
+	color: rgb(91, 91, 91);
 }
 
 .entry-meta a {
-	color: rgb(179, 179, 179);
+	color: rgb(91, 91, 91);
 }
 
 .cat-links {


### PR DESCRIPTION
The colour contrast of the post meta links scores quite low according to [Contrast Ratio](https://contrast-ratio.com/). This PR attempts to fix this resulting in a 100/100 score for accessibility in the Chrome Lighthouse tests.

The text remains grey but is now much more visible.

(Also sorry about the commit history, I messed up the branches - all fixed now!)

---

_Note: as I already had another open PR I had to add this to a different branch (`fix/link-contrast`). Hopefully this doesn't cause issues and is easy to merge if you're happy with this._