### PR TITLE
Embeds: add support for Core Responsive Embeds

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -79,6 +79,13 @@ if ( ! function_exists( 'susty_setup' ) ) :
 			'flex-width'  => true,
 			'flex-height' => true,
 		) );
+
+		/**
+		 * Add support for Responsive embeds.
+		 *
+		 * @link https://developer.wordpress.org/block-editor/developers/themes/theme-support/#responsive-embedded-content
+		 */
+		add_theme_support( 'responsive-embeds' );
 	}
 endif;
 add_action( 'after_setup_theme', 'susty_setup' );


### PR DESCRIPTION
This allows embeds like Videos to look better when using custom block styles such as the "Full Width" embeds.

Related discussion:
https://github.com/Automattic/jetpack/issues/13187
